### PR TITLE
Avoid running the generator twice (on average) for limit=2^N

### DIFF
--- a/lcg128.el
+++ b/lcg128.el
@@ -73,8 +73,8 @@ returned unshifted for efficiency."
               (lsh (lcg128--next state) (- rem 128))))))
 
 (cl-defun lcg128-range (limit &optional (state lcg128--state))
-  "Return a random integer in [0 – limit) without bias."
-  (let ((nbits (1+ (logb limit))))
+  "Return a random integer in [0,limit) without bias."
+  (let ((nbits (1+ (max 0 (logb (1- limit))))))
     (cl-loop for result = (lcg128-bits nbits state)
              then (lcg128-bits nbits state)
              until (< result limit)


### PR DESCRIPTION
For limit=2^N, we should generate only N bits of entropy, and never repeatedly call the generator.

This changes the benchmark results significantly.